### PR TITLE
Rebrand Cloud Functions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@ more Code Pattern repositories.
 ## Methodology
 
 This repository does not have a traditional release management cycle, but
-should instead be maintained as as a useful, working, and polished reference at
+should instead be maintained as a useful, working, and polished reference at
 all times. While all work can therefore be focused on the master branch, the
 quality of this branch should never be compromised.
 

--- a/OW-NAPI-README.md
+++ b/OW-NAPI-README.md
@@ -1,26 +1,26 @@
-## Create secured APIs for your OpenWhisk actions on Bluemix
+## Create secured APIs for your IBM Cloud Functions
 
 *Read this in other languages: [한국어](OW-NAPI-README-ko.md).*
 
-### Creating an API for your OpenWhisk actions on Bluemix
+### Creating an API for your IBM Cloud Functions
 
-Once the [toolchain is installed](TOOLCHAIN-README.md), a set of OpenWhisk actions will get deployed to the region and space you chose when creating the toolchain. You can view them in the [OpenWhisk dashboard on Bluemix](https://console.ng.bluemix.net/openwhisk/manage/actions). Whenever a storm is simulated, the OpenWhisk actions are utilized to generate recommendations.
+Once the [toolchain is installed](TOOLCHAIN-README.md), a set of Cloud Function actions will get deployed to the region and space you chose when creating the toolchain. You can view them in the [Cloud Functions dashboard](https://cloud.ibm.com/openwhisk/manage/actions). Whenever a storm is simulated, the Cloud Function actions are utilized to generate recommendations.
 
-<img src="docs/actions.png" alt="OpenWhisk actions" width="600">
+<img src="docs/actions.png" alt="Cloud Function actions" width="600">
 
 #### Create API and Endpoints
 
-To expose these OpenWhisk actions as a part of an API, we need to click the APIs link near the top of the Bluemix OpenWhisk interface. And then click on the Create an OpenWhisk API button.
+To expose these Cloud Function actions as a part of an API, we need to click the APIs link near the top of the IBM Cloud Functions interface. And then click on the Create an Cloud Functions API button.
 
-1. Create a name for your API. I chose `Acme Freight OpenWhisk API`
+1. Create a name for your API. I chose `Acme Freight Cloud Functions API`
 
 2. Click Create Operation button to begin adding your endpoints.
 
-Name each endpoint to correspond with each OpenWhisk action. Choose `POST` as your Verb. Below is an example:
+Name each endpoint to correspond with each Cloud Function action. Choose `POST` as your Verb. Below is an example:
 
 <img src="docs/endpoint-modal.png" alt="Create operation endpoints" width="500">
 
-Repeat above to make an endpoint corresponding with each OpenWhisk action.
+Repeat above to make an endpoint corresponding with each Cloud Function action.
 
 Your resulting page should look like the image below:
 
@@ -57,11 +57,11 @@ The last thing you'll need is the full path to your APIs, which you can find on 
 
 ### Configure the controller application to use your newly created secure API endpoints
 
-Now that we've created the secure endpoints, we need to update the Acme Freight microservice that calls the OpenWhisk actions. The controller application already has the code to call a secured endpoint; we simply need to tell the application your secured API URL and API key that you created earlier.
+Now that we've created the secure endpoints, we need to update the Acme Freight microservice that calls the Cloud Function actions. The controller application already has the code to call a secured endpoint; we simply need to tell the application your secured API URL and API key that you created earlier.
 
 _Note: Using environment configuration is the best practice for updating the backend services that the controller needs. To access the secured API, the controller code checks if an API URL and API key are provided and uses them for requests. [See the code](https://github.com/IBM/acme-freight-controller/blob/dev/server/utils.py#L76)_
 
-Jump to your [Bluemix DevOps toolchains](https://console.ng.bluemix.net/devops/toolchains) and click the toolchain you created for Acme Freight. You should then see the following screen, click on the square under `Deliver` for the `controller` pipeline:
+Jump to your [IBM Cloud DevOps toolchains](https://cloud.ibm.com/devops/toolchains) and click the toolchain you created for Acme Freight. You should then see the following screen, click on the square under `Deliver` for the `controller` pipeline:
 
 <img src="docs/toolchains.png" alt="Toolchains" width="700">
 
@@ -77,7 +77,7 @@ Then hit save, go back to the pipeline and hit the `Run Stage` button:
 
 <img src="docs/run-stage.png" alt="Run stage" width="300">
 
-With just those few clicks, the Acme Freight application is now accessing secured OpenWhisk actions! Here are some of the advantages to securing our OpenWhisk actions:
-- Set a safe rate-limit setting to protect your application (and your credit card) from malicious spamming against your OpenWhisk actions.
-- Reveal your OpenWhisk endpoints to other consumer applications, not just Acme Freight. By creating API keys for each application that needs access to these APIs, you can individually track and manage consumers and even revoke access if ever necessary.
+With just those few clicks, the Acme Freight application is now accessing secured Cloud Function actions! Here are some of the advantages to securing our Cloud Function actions:
+- Set a safe rate-limit setting to protect your application (and your credit card) from malicious spamming against your Cloud Function actions.
+- Reveal your Cloud Function endpoints to other consumer applications, not just Acme Freight. By creating API keys for each application that needs access to these APIs, you can individually track and manage consumers and even revoke access if ever necessary.
 - Utilize the analytics view to see how often your APIs are being called and how long they take to fulfill. This enables you to track down latency issues as they arise.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Acme Freight Shipping is a fictional shipping and logistics company using the [Logistics Wizard](https://github.com/ibm-bluemix/logistics-wizard) application framework to reimagine supply chain optimization systems for the 21st century.
 
-Acme Freight uses an application, called [Logistic Wizard](https://github.com/ibm-bluemix/logistics-wizard) to manage some of its assets. The application is composed of several microservices, including three Cloud Foundry applications and multiple OpenWhisk actions.
+Acme Freight uses an application, called [Logistic Wizard](https://github.com/ibm-bluemix/logistics-wizard) to manage some of its assets. The application is composed of several microservices, including three Cloud Foundry applications and multiple Cloud Function actions.
 
 Acme Freight uses LoopBack, an open source Node.js framework, built for quickly creating and exposing APIs for new and existing applications and data. LoopBack enables Acme Freight to create an application that integrates with their existing ERP system, and API Connect allows them to expose data via a managed API.
 
@@ -21,8 +21,8 @@ To start learning more about Acme Freight and the technology behind it, jump to 
 ### Rapidly Create APIs with the Node API Framework, LoopBack 
 * [Use LoopBack and API Connect to rapidly expose ERP data with APIs](APIC-ERP-README.md) 
 
-### Create secured APIs for OpenWhisk actions in just a few clicks
-* [Create secured APIs for your OpenWhisk actions on Bluemix](OW-NAPI-README.md) 
+### Create secured APIs for Cloud Function actions in just a few clicks
+* [Create secured APIs for your Cloud Function actions on Bluemix](OW-NAPI-README.md) 
 
 ## Acme Freight Overview
 The video below demonstates how Acme Freight Shipping used the Logistics Wizard framework, along with IBM API Connect, to deliver an application allowing them to revolutionize the agility of their supply chain.
@@ -39,7 +39,7 @@ The following projects are leveraged in the overall Acme Freight solution:
 
 * [acme-freight-webui](https://github.com/ibm/acme-freight-webui) - provides a dashboard to view ongoing shipments and alerts. There is no log-in or user credentials per se to use the deployed applications. Instead a unique demo ID is assigned to any new user trying the application. Behind each demo ID, Acme Freight creates an isolated environment with a default set of business users, distribution centers, retail stores, shipments. Refer to the [walkthrough](WALKTHROUGH.md) to get a tour of the capabilities.
 
-* [acme-freight-recommendation](https://github.com/ibm/acme-freight-recommendation) - makes shipment recommendations based on weather conditions. It is a set of Bluemix OpenWhisk to retrieve current weather conditions and given a weather event to generate new shipment recommendations. These recommendations could then be turned into real orders.
+* [acme-freight-recommendation](https://github.com/ibm/acme-freight-recommendation) - makes shipment recommendations based on weather conditions. It is a set of IBM Cloud Functions to retrieve current weather conditions and given a weather event to generate new shipment recommendations. These recommendations could then be turned into real orders.
 
 * [acme-freight-controller](https://github.com/ibm/acme-freight-controller) - acts as the main controller for interaction between the services. It receives requests from the user interface and routes them to the ERP or the weather recommendation module.
 
@@ -53,7 +53,7 @@ The following projects are leveraged in the overall Acme Freight solution:
 
 ## License
 
-This code pattern is licensed under the Apache Software License, Version 2.  Separate third party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the [Developer Certificate of Origin, Version 1.1 (DCO)](https://developercertificate.org/) and the [Apache Software License, Version 2](http://www.apache.org/licenses/LICENSE-2.0.txt).
+This code pattern is licensed under the Apache Software License, Version 2. Separate third party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the [Developer Certificate of Origin, Version 1.1](https://developercertificate.org/) and the [Apache License, Version 2](https://www.apache.org/licenses/LICENSE-2.0.txt).
 
-[Apache Software License (ASL) FAQ](http://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN)
+[Apache License FAQ](https://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN)
 


### PR DESCRIPTION
Replace references to 'Bluemix OpenWhisk' with 'IBM Cloud Functions'
Typo in MAINTAINERS

Fixes #22